### PR TITLE
3DS support

### DIFF
--- a/asio/include/asio/detail/impl/socket_select_interrupter.ipp
+++ b/asio/include/asio/detail/impl/socket_select_interrupter.ipp
@@ -21,7 +21,8 @@
 
 #if defined(ASIO_WINDOWS) \
   || defined(__CYGWIN__) \
-  || defined(__SYMBIAN32__)
+  || defined(__SYMBIAN32__) \
+  || defined(__3DS__)
 
 #include <cstdlib>
 #include "asio/detail/socket_holder.hpp"

--- a/asio/include/asio/detail/impl/socket_select_interrupter.ipp
+++ b/asio/include/asio/detail/impl/socket_select_interrupter.ipp
@@ -60,7 +60,11 @@ void socket_select_interrupter::open_descriptors()
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   addr.sin_addr.s_addr = socket_ops::host_to_network_long(INADDR_LOOPBACK);
+#ifndef __3DS__
   addr.sin_port = 0;
+#else
+  addr.sin_port = 5000;
+#endif
   if (socket_ops::bind(acceptor.get(), (const socket_addr_type*)&addr,
         addr_len, ec) == socket_error_retval)
     asio::detail::throw_error(ec, "socket_select_interrupter");

--- a/asio/include/asio/detail/select_interrupter.hpp
+++ b/asio/include/asio/detail/select_interrupter.hpp
@@ -19,7 +19,7 @@
 
 #if !defined(ASIO_WINDOWS_RUNTIME)
 
-#if defined(ASIO_WINDOWS) || defined(__CYGWIN__) || defined(__SYMBIAN32__)
+#if defined(ASIO_WINDOWS) || defined(__CYGWIN__) || defined(__SYMBIAN32__) || defined(__3DS__)
 # include "asio/detail/socket_select_interrupter.hpp"
 #elif defined(ASIO_HAS_EVENTFD)
 # include "asio/detail/eventfd_select_interrupter.hpp"
@@ -30,7 +30,7 @@
 namespace asio {
 namespace detail {
 
-#if defined(ASIO_WINDOWS) || defined(__CYGWIN__) || defined(__SYMBIAN32__)
+#if defined(ASIO_WINDOWS) || defined(__CYGWIN__) || defined(__SYMBIAN32__) || defined(__3DS__)
 typedef socket_select_interrupter select_interrupter;
 #elif defined(ASIO_HAS_EVENTFD)
 typedef eventfd_select_interrupter select_interrupter;

--- a/asio/include/asio/detail/socket_select_interrupter.hpp
+++ b/asio/include/asio/detail/socket_select_interrupter.hpp
@@ -21,7 +21,8 @@
 
 #if defined(ASIO_WINDOWS) \
   || defined(__CYGWIN__) \
-  || defined(__SYMBIAN32__)
+  || defined(__SYMBIAN32__) \
+  || defined(__3DS__)
 
 #include "asio/detail/socket_types.hpp"
 


### PR DESCRIPTION
* 3DS doesn't support the `pipe()` system call, so it needs to use the `socket_select_interrupter`.
* 3DS can't open a socket on port 0, so I hardcoded it to 5000. I suspect this won't cause conflicts since, as far as I know, the 3DS doesn't support multitasking. The port is arbitrary, though, so we could change it to something a bit more random if we want.