### PR TITLE
Switch support

### DIFF
--- a/asio/include/asio/detail/impl/socket_select_interrupter.ipp
+++ b/asio/include/asio/detail/impl/socket_select_interrupter.ipp
@@ -22,6 +22,7 @@
 #if defined(ASIO_WINDOWS) \
   || defined(__CYGWIN__) \
   || defined(__SYMBIAN32__) \
+  || defined(__SWITCH__) \
   || defined(__3DS__)
 
 #include <cstdlib>

--- a/asio/include/asio/detail/select_interrupter.hpp
+++ b/asio/include/asio/detail/select_interrupter.hpp
@@ -19,7 +19,7 @@
 
 #if !defined(ASIO_WINDOWS_RUNTIME)
 
-#if defined(ASIO_WINDOWS) || defined(__CYGWIN__) || defined(__SYMBIAN32__) || defined(__3DS__)
+#if defined(ASIO_WINDOWS) || defined(__CYGWIN__) || defined(__SYMBIAN32__) || defined(__SWITCH__) || defined(__3DS__)
 # include "asio/detail/socket_select_interrupter.hpp"
 #elif defined(ASIO_HAS_EVENTFD)
 # include "asio/detail/eventfd_select_interrupter.hpp"
@@ -30,7 +30,7 @@
 namespace asio {
 namespace detail {
 
-#if defined(ASIO_WINDOWS) || defined(__CYGWIN__) || defined(__SYMBIAN32__) || defined(__3DS__)
+#if defined(ASIO_WINDOWS) || defined(__CYGWIN__) || defined(__SYMBIAN32__) || defined(__SWITCH__) || defined(__3DS__)
 typedef socket_select_interrupter select_interrupter;
 #elif defined(ASIO_HAS_EVENTFD)
 typedef eventfd_select_interrupter select_interrupter;

--- a/asio/include/asio/detail/socket_select_interrupter.hpp
+++ b/asio/include/asio/detail/socket_select_interrupter.hpp
@@ -22,6 +22,7 @@
 #if defined(ASIO_WINDOWS) \
   || defined(__CYGWIN__) \
   || defined(__SYMBIAN32__) \
+  || defined(__SWITCH__) \
   || defined(__3DS__)
 
 #include "asio/detail/socket_types.hpp"


### PR DESCRIPTION
Switch does not support the `pipe` syscall and so needs to use the `socket_select_interrupter`.