### PR TITLE
UTF-8 system error messages on Windows

### DIFF
--- a/asio/include/asio/impl/error_code.ipp
+++ b/asio/include/asio/impl/error_code.ipp
@@ -44,7 +44,7 @@ public:
 
   std::string message(int value) const
   {
-#if defined(ASIO_WINDOWS_RUNTIME) || defined(ASIO_WINDOWS_APP)
+#if defined(ASIO_WINDOWS_RUNTIME) || defined(ASIO_WINDOWS_APP) || (defined(ASIO_WINDOWS) && _WIN32_WINNT >= 0x0501)
     std::wstring wmsg(128, wchar_t());
     for (;;)
     {


### PR DESCRIPTION
Discord user cucamorais reported that his error messages were being cut off so he couldn't troubleshoot TCP port forwarding.

![image](https://github.com/user-attachments/assets/e8b9f2fb-aeb2-4148-b4e0-c2a29e187b5c)

Obviously, we're not sure what the full error message would have been in this case, but here is an example of one that it likely could have been.

> Nenhuma conexão pôde ser feita porque a máquina de destino as recusou ativamente.

A bit of digging revealed that ASIO was using `FormatMessageA()` to produce an ANSI-encoded string for the error message. The Windows-1252 codepoint for `ã` is 0xe3, which is not a valid UTF-8 codepoint. Our UTF-8 decoder fails to read the string after this point, which explains why it gets cut off.

According to Microsoft documentation, the `FormatMessageW()` function should be supported since Windows XP. This PR adds a condition to prefer `FormatMessageW()` on Windows XP or later.