### PR TITLE
Add missing #include <exception>

### DIFF
--- a/asio/include/asio/execution/detail/as_receiver.hpp
+++ b/asio/include/asio/execution/detail/as_receiver.hpp
@@ -15,6 +15,8 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#include <exception>
+
 #include "asio/detail/config.hpp"
 #include "asio/detail/type_traits.hpp"
 #include "asio/traits/set_done_member.hpp"

--- a/asio/include/asio/execution/receiver_invocation_error.hpp
+++ b/asio/include/asio/execution/receiver_invocation_error.hpp
@@ -15,9 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
-#include "asio/detail/config.hpp"
+#include <exception>
 #include <stdexcept>
 
+#include "asio/detail/config.hpp"
 #include "asio/detail/push_options.hpp"
 
 namespace asio {


### PR DESCRIPTION
`std::nested_exception` and `std::terminate` are declared in `<exception>`.