### PR TITLE
Fix -Wdeprecated-literal-operator

### DIFF
--- a/asio/include/asio/buffer.hpp
+++ b/asio/include/asio/buffer.hpp
@@ -2881,7 +2881,7 @@ struct literal<'0', 'X', Chars...> :
 } // namespace detail
 
 /// Literal operator for creating const_buffer objects from string literals.
-inline ASIO_CONST_BUFFER operator"" _buf(const char* data, std::size_t n)
+inline ASIO_CONST_BUFFER operator""_buf(const char* data, std::size_t n)
 {
   return ASIO_CONST_BUFFER(data, n);
 }
@@ -2889,7 +2889,7 @@ inline ASIO_CONST_BUFFER operator"" _buf(const char* data, std::size_t n)
 /// Literal operator for creating const_buffer objects from unbounded binary or
 /// hexadecimal integer literals.
 template <char... Chars>
-inline ASIO_CONST_BUFFER operator"" _buf()
+inline ASIO_CONST_BUFFER operator""_buf()
 {
   return ASIO_CONST_BUFFER(
       +detail::literal<Chars...>::data,


### PR DESCRIPTION
Fixes the following warning:

```
include/asio/buffer.hpp:2892:36: warning: space between quotes and suffix is deprecated in C++23 [-Wdeprecated-literal-operator]
 2892 | inline ASIO_CONST_BUFFER operator"" _buf()
      |                                    ^~
      |                                    --
```